### PR TITLE
feat: add ability to provide an existing secret for localUsers so that passwords can be kept outside of the values.yaml

### DIFF
--- a/charts/ff-common/Chart.yaml
+++ b/charts/ff-common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ff-common
 description: ff-common chart building components and helpers for the Frank!Framework
-version: 0.1.25
+version: 0.2.0
 appVersion: "8.0"
 type: library
 home: https://frankframework.org

--- a/charts/ff-common/README.md
+++ b/charts/ff-common/README.md
@@ -58,6 +58,7 @@ Whereas the sub-chart can only be used "as is", the library can be modified in y
 | `frank.security.http.localUsers.username`                    | Set the username of the user                                                                                     | `undefined` |
 | `frank.security.http.localUsers.password`                    | Set the password of the user                                                                                     | `undefined` |
 | `frank.security.http.localUsers.roles`                       | Set the roles of the user. Options: `IbisTester`, `IbisDataAdmin`, `IbisAdmin`, `IbisWebService`, `IbisObserver` | `undefined` |
+| `frank.security.http.localUsersExistingSecret`               | The name of the existing secret, containing the 'tomcat-users.xml' and 'localUsers.yml' files.                   | `""`        |
 | `frank.security.http.activeDirectory.enabled`                | Enable Active Directory for authentication                                                                       | `false`     |
 | `frank.security.http.activeDirectory.url`                    | Set url for Active Directory                                                                                     | `""`        |
 | `frank.security.http.activeDirectory.baseDn`                 | Set baseDn for Active Directory users                                                                            | `""`        |

--- a/charts/ff-common/templates/_configmap.env.yaml
+++ b/charts/ff-common/templates/_configmap.env.yaml
@@ -40,7 +40,7 @@ data:
   # Reverse proxy/ingress should be used for https
   application.security.http.transportGuarantee: "NONE"
   {{- if .Values.frank.security.http.authentication }}
-  {{- if .Values.frank.security.http.localUsers }}
+  {{- if (or .Values.frank.security.http.localUsers .Values.frank.security.http.localUsersExistingSecret) }}
   application.security.console.authentication.type: "YML"
   {{- end }}
   {{- with .Values.frank.security.http.activeDirectory.enabled }}

--- a/charts/ff-common/templates/_configmap.tomcat-users.yaml
+++ b/charts/ff-common/templates/_configmap.tomcat-users.yaml
@@ -2,7 +2,7 @@
 ConfigMap for generating a tomcat-users.xml including all users and roles
 */}}
 {{- define "ff-common.configmap.tomcat-users.tpl" -}}
-{{- if .Values.frank.security.http.localUsers -}}
+{{- if and .Values.frank.security.http.localUsers (not .Values.frank.security.http.localUsersExistingSecret) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/ff-common/templates/_deployment.yaml
+++ b/charts/ff-common/templates/_deployment.yaml
@@ -61,10 +61,15 @@ spec:
           secret:
             secretName: {{ .Values.frank.credentials.secret }}
         {{- end }}
-        {{- if .Values.frank.security.http.localUsers }}
+        {{- if (or .Values.frank.security.http.localUsers .Values.frank.security.http.localUsersExistingSecret) }}
         - name: {{ template "ff-common.fullname" . }}-tomcat-users
+          {{- if .Values.frank.security.http.localUsersExistingSecret }}
+          secret:
+            secretName: {{ tpl .Values.frank.security.http.localUsersExistingSecret . }}
+          {{- else }}
           configMap:
             name: {{ template "ff-common.fullname" . }}-tomcat-users
+          {{- end }}
         {{- end }}
         {{- if .Values.connections.create }}
         - name: {{ template "ff-common.fullname" . }}-context

--- a/charts/ff-common/values.schema.json
+++ b/charts/ff-common/values.schema.json
@@ -146,6 +146,12 @@
                                         "type": "string"
                                     }
                                 },
+                                "localUsersExistingSecret": {
+                                    "type": "string",
+                                    "description": "The name of the existing secret, containing the 'tomcat-users.xml' and 'localUsers.yml' files.",
+                                    "default": "",
+                                    "nullable": true
+                                },
                                 "activeDirectory": {
                                     "type": "object",
                                     "properties": {

--- a/charts/ff-common/values.yaml
+++ b/charts/ff-common/values.yaml
@@ -99,6 +99,12 @@ frank:
       ##        - IbisTester
       ##
       localUsers: []
+      ## @param frank.security.http.localUsersExistingSecret [string, nullable] The name of the existing secret, containing the 'tomcat-users.xml' and 'localUsers.yml' files.
+      ## e.g.
+      ## localUsersExistingSecret: >- 
+      ##   {{ template "ff-common.fullname" . }}-my-own-tomcat-users
+      ##
+      localUsersExistingSecret: ""
       ## @param frank.security.http.activeDirectory.enabled Enable Active Directory for authentication
       ## @param frank.security.http.activeDirectory.url Set url for Active Directory
       ## @param frank.security.http.activeDirectory.baseDn Set baseDn for Active Directory users


### PR DESCRIPTION
The name is not great, but did not want to introduce a breaking change by turning in `localUsers` into an object and have `existingSecret` under that.